### PR TITLE
Minor tweaks to correct issues in CMIP6Plus_CV.json generation

### DIFF
--- a/.github/libs/create_cv.py
+++ b/.github/libs/create_cv.py
@@ -151,8 +151,11 @@ for key in 'source_type frequency realm grid_label nominal_resolution'.split():
 institutions = {**read_json_from_github('PCMDI', mip_tables, 'main', f'{table_prefix}institutions.json'),**read_json_from_github('PCMDI', mip_tables, 'main', f'{table_prefix}consortiums.json')}
 
 def mapinst(i):
-    if i in institutions: 
-        return f"{institutions[i]['indentifiers']['ror']} - {institutions[i]['indentifiers']['institution_name']}"
+    if i in institutions:
+        if institutions[i]['indentifiers']['ror']:
+            return f"{institutions[i]['indentifiers']['ror']} - {institutions[i]['indentifiers']['institution_name']}"
+        else:
+            return f"{institutions[i]['indentifiers']['institution_name']}"
     elif i in institutions['consortiums']:
         return f"{i} - {institutions['consortiums'][i]['name']} [consortium]"
     else: 
@@ -254,7 +257,7 @@ for entry in structure:
 
                 components_str = "\n".join(components)
 
-                CV[entry][model]['source'] = f"{model_info['source_id']} ({model_info['release_year']}: \n{components_str})"
+                CV[entry][model]['source'] = f"{model_info['source_id']} ({model_info['release_year']}): \n{components_str})"
                 
                 
                 for d in 'model_component release_year label label_extended'.split():

--- a/.github/libs/tag.py
+++ b/.github/libs/tag.py
@@ -39,6 +39,7 @@ w,x,y,z = map(int,version.strip('v').strip().split('.'))
 MIPERA = 'CMIP6Plus'
 new = OrderedDict(repo=dict(mipera=MIPERA,repo=repo,url=url),changelog={})
 comment = ''
+new['repo']['version'] = 'none'
 
 if branch == 'main':
   

--- a/.github/libs/tag.py
+++ b/.github/libs/tag.py
@@ -36,13 +36,12 @@ except:
     
 w,x,y,z = map(int,version.strip('v').strip().split('.'))
 
+MIPERA = 'CMIP6Plus'
+new = OrderedDict(repo=dict(mipera=MIPERA,repo=repo,url=url),changelog={})
+comment = ''
 
 if branch == 'main':
-
-    MIPERA = 'CMIP6Plus'
-    new = OrderedDict(repo=dict(mipera=MIPERA,repo=repo,url=url),changelog={})
-    comment = ''
-
+  
     #  If not wcrp-cmip, do not create this. 
 
     files = ['activity_id','experiment_id','source_id']

--- a/CMIP6Plus_DRS.json
+++ b/CMIP6Plus_DRS.json
@@ -2,15 +2,15 @@
     "Header": {
         "collection": {
             "CV_collection_version": "v6.5.1.0",
-            "CV_collection_modified": "2023-11-20T16:32:10Z",
-            "CV_collection_release": "https://github.com/WCRP-CMIP/CMIP6Plus_CVs/releases/tag/v6.5.0.0",
+            "CV_collection_modified": "2024-02-12T16:13:34Z",
+            "CV_collection_release": "https://github.com/WCRP-CMIP/CMIP6Plus_CVs/releases/tag/v6.5.1.0",
             "specs_doc": "v6.5.0"
         },
         "file": {
             "checksum": "md5: 87c4ebd7d94fc626cbbf6c848a978996",
-            "DRS_update_commit": "8a5ecc14d6a5d84c4a828f67fd537f4daf80d761",
-            "DRS_modified": "Mon Feb 12 16:11:03 2024 +0000",
-            "DRS_note": "Tag and Release (#56)"
+            "DRS_update_commit": "",
+            "DRS_modified": "",
+            "DRS_note": ""
         },
         "author": "Daniel Ellis",
         "institution_id": "CMIP-IPO"

--- a/CMIP6Plus_activity_id.json
+++ b/CMIP6Plus_activity_id.json
@@ -2,15 +2,15 @@
     "Header": {
         "collection": {
             "CV_collection_version": "v6.5.1.0",
-            "CV_collection_modified": "2023-11-20T16:32:10Z",
-            "CV_collection_release": "https://github.com/WCRP-CMIP/CMIP6Plus_CVs/releases/tag/v6.5.0.0",
+            "CV_collection_modified": "2024-02-12T16:13:34Z",
+            "CV_collection_release": "https://github.com/WCRP-CMIP/CMIP6Plus_CVs/releases/tag/v6.5.1.0",
             "specs_doc": "v6.5.0"
         },
         "file": {
             "checksum": "md5: 13f76cb7b0cd1075fcb440b6e22afb64",
-            "activity_id_update_commit": "8a5ecc14d6a5d84c4a828f67fd537f4daf80d761",
-            "activity_id_modified": "Mon Feb 12 16:11:03 2024 +0000",
-            "activity_id_note": "Tag and Release (#56)"
+            "activity_id_update_commit": "",
+            "activity_id_modified": "",
+            "activity_id_note": ""
         },
         "author": "Daniel Ellis",
         "institution_id": "CMIP-IPO"

--- a/CMIP6Plus_experiment_id.json
+++ b/CMIP6Plus_experiment_id.json
@@ -2,15 +2,15 @@
     "Header": {
         "collection": {
             "CV_collection_version": "v6.5.1.0",
-            "CV_collection_modified": "2023-11-20T16:32:10Z",
-            "CV_collection_release": "https://github.com/WCRP-CMIP/CMIP6Plus_CVs/releases/tag/v6.5.0.0",
+            "CV_collection_modified": "2024-02-12T16:13:34Z",
+            "CV_collection_release": "https://github.com/WCRP-CMIP/CMIP6Plus_CVs/releases/tag/v6.5.1.0",
             "specs_doc": "v6.5.0"
         },
         "file": {
             "checksum": "md5: 1a4a72c633e489915a42fd482466a494",
-            "experiment_id_update_commit": "8a5ecc14d6a5d84c4a828f67fd537f4daf80d761",
-            "experiment_id_modified": "Mon Feb 12 16:11:03 2024 +0000",
-            "experiment_id_note": "Tag and Release (#56)"
+            "experiment_id_update_commit": "",
+            "experiment_id_modified": "",
+            "experiment_id_note": ""
         },
         "author": "Daniel Ellis",
         "institution_id": "CMIP-IPO"

--- a/CMIP6Plus_license.json
+++ b/CMIP6Plus_license.json
@@ -2,15 +2,15 @@
     "Header": {
         "collection": {
             "CV_collection_version": "v6.5.1.0",
-            "CV_collection_modified": "2023-11-20T16:32:10Z",
-            "CV_collection_release": "https://github.com/WCRP-CMIP/CMIP6Plus_CVs/releases/tag/v6.5.0.0",
+            "CV_collection_modified": "2024-02-12T16:13:34Z",
+            "CV_collection_release": "https://github.com/WCRP-CMIP/CMIP6Plus_CVs/releases/tag/v6.5.1.0",
             "specs_doc": "v6.5.0"
         },
         "file": {
             "checksum": "md5: 6239ce228dc3dc4f7aca7035ddced0c2",
-            "license_update_commit": "8a5ecc14d6a5d84c4a828f67fd537f4daf80d761",
-            "license_modified": "Mon Feb 12 16:11:03 2024 +0000",
-            "license_note": "Tag and Release (#56)"
+            "license_update_commit": "",
+            "license_modified": "",
+            "license_note": ""
         },
         "author": "Daniel Ellis",
         "institution_id": "CMIP-IPO"

--- a/CMIP6Plus_mip_era.json
+++ b/CMIP6Plus_mip_era.json
@@ -2,15 +2,15 @@
     "Header": {
         "collection": {
             "CV_collection_version": "v6.5.1.0",
-            "CV_collection_modified": "2023-11-20T16:32:10Z",
-            "CV_collection_release": "https://github.com/WCRP-CMIP/CMIP6Plus_CVs/releases/tag/v6.5.0.0",
+            "CV_collection_modified": "2024-02-12T16:13:34Z",
+            "CV_collection_release": "https://github.com/WCRP-CMIP/CMIP6Plus_CVs/releases/tag/v6.5.1.0",
             "specs_doc": "v6.5.0"
         },
         "file": {
             "checksum": "md5: 15ab5b39a4b62012e371f14e3c2afbfc",
-            "mip_era_update_commit": "8a5ecc14d6a5d84c4a828f67fd537f4daf80d761",
-            "mip_era_modified": "Mon Feb 12 16:11:03 2024 +0000",
-            "mip_era_note": "Tag and Release (#56)"
+            "mip_era_update_commit": "",
+            "mip_era_modified": "",
+            "mip_era_note": ""
         },
         "author": "Daniel Ellis",
         "institution_id": "CMIP-IPO"

--- a/CMIP6Plus_product.json
+++ b/CMIP6Plus_product.json
@@ -2,15 +2,15 @@
     "Header": {
         "collection": {
             "CV_collection_version": "v6.5.1.0",
-            "CV_collection_modified": "2023-11-20T16:32:10Z",
-            "CV_collection_release": "https://github.com/WCRP-CMIP/CMIP6Plus_CVs/releases/tag/v6.5.0.0",
+            "CV_collection_modified": "2024-02-12T16:13:34Z",
+            "CV_collection_release": "https://github.com/WCRP-CMIP/CMIP6Plus_CVs/releases/tag/v6.5.1.0",
             "specs_doc": "v6.5.0"
         },
         "file": {
             "checksum": "md5: 0f0c81450ca204c2c537226f19927022",
-            "product_update_commit": "8a5ecc14d6a5d84c4a828f67fd537f4daf80d761",
-            "product_modified": "Mon Feb 12 16:11:03 2024 +0000",
-            "product_note": "Tag and Release (#56)"
+            "product_update_commit": "",
+            "product_modified": "",
+            "product_note": ""
         },
         "author": "Daniel Ellis",
         "institution_id": "CMIP-IPO"

--- a/CMIP6Plus_required_global_attributes.json
+++ b/CMIP6Plus_required_global_attributes.json
@@ -2,15 +2,15 @@
     "Header": {
         "collection": {
             "CV_collection_version": "v6.5.1.0",
-            "CV_collection_modified": "2023-11-20T16:32:10Z",
-            "CV_collection_release": "https://github.com/WCRP-CMIP/CMIP6Plus_CVs/releases/tag/v6.5.0.0",
+            "CV_collection_modified": "2024-02-12T16:13:34Z",
+            "CV_collection_release": "https://github.com/WCRP-CMIP/CMIP6Plus_CVs/releases/tag/v6.5.1.0",
             "specs_doc": "v6.5.0"
         },
         "file": {
             "checksum": "md5: 707ac1977a119878fc4fa113b3e2e67f",
-            "required_global_attributes_update_commit": "8a5ecc14d6a5d84c4a828f67fd537f4daf80d761",
-            "required_global_attributes_modified": "Mon Feb 12 16:11:03 2024 +0000",
-            "required_global_attributes_note": "Tag and Release (#56)"
+            "required_global_attributes_update_commit": "",
+            "required_global_attributes_modified": "",
+            "required_global_attributes_note": ""
         },
         "author": "Daniel Ellis",
         "institution_id": "CMIP-IPO"

--- a/CMIP6Plus_source_id.json
+++ b/CMIP6Plus_source_id.json
@@ -2,15 +2,15 @@
     "Header": {
         "collection": {
             "CV_collection_version": "v6.5.1.0",
-            "CV_collection_modified": "2023-11-20T16:32:10Z",
-            "CV_collection_release": "https://github.com/WCRP-CMIP/CMIP6Plus_CVs/releases/tag/v6.5.0.0",
+            "CV_collection_modified": "2024-02-12T16:13:34Z",
+            "CV_collection_release": "https://github.com/WCRP-CMIP/CMIP6Plus_CVs/releases/tag/v6.5.1.0",
             "specs_doc": "v6.5.0"
         },
         "file": {
             "checksum": "md5: 3f8858d55a1c5d022c51ed17240832a0",
-            "source_id_update_commit": "8a5ecc14d6a5d84c4a828f67fd537f4daf80d761",
-            "source_id_modified": "Mon Feb 12 16:11:03 2024 +0000",
-            "source_id_note": "Tag and Release (#56)"
+            "source_id_update_commit": "",
+            "source_id_modified": "",
+            "source_id_note": ""
         },
         "author": "Daniel Ellis",
         "institution_id": "CMIP-IPO"

--- a/CMIP6Plus_sub_experiment_id.json
+++ b/CMIP6Plus_sub_experiment_id.json
@@ -2,15 +2,15 @@
     "Header": {
         "collection": {
             "CV_collection_version": "v6.5.1.0",
-            "CV_collection_modified": "2023-11-20T16:32:10Z",
-            "CV_collection_release": "https://github.com/WCRP-CMIP/CMIP6Plus_CVs/releases/tag/v6.5.0.0",
+            "CV_collection_modified": "2024-02-12T16:13:34Z",
+            "CV_collection_release": "https://github.com/WCRP-CMIP/CMIP6Plus_CVs/releases/tag/v6.5.1.0",
             "specs_doc": "v6.5.0"
         },
         "file": {
             "checksum": "md5: 96bc2528e51412d3d8ab2889170bd0ed",
-            "sub_experiment_id_update_commit": "8a5ecc14d6a5d84c4a828f67fd537f4daf80d761",
-            "sub_experiment_id_modified": "Mon Feb 12 16:11:03 2024 +0000",
-            "sub_experiment_id_note": "Tag and Release (#56)"
+            "sub_experiment_id_update_commit": "",
+            "sub_experiment_id_modified": "",
+            "sub_experiment_id_note": ""
         },
         "author": "Daniel Ellis",
         "institution_id": "CMIP-IPO"

--- a/CMIP6Plus_tracking_id.json
+++ b/CMIP6Plus_tracking_id.json
@@ -2,15 +2,15 @@
     "Header": {
         "collection": {
             "CV_collection_version": "v6.5.1.0",
-            "CV_collection_modified": "2023-11-20T16:32:10Z",
-            "CV_collection_release": "https://github.com/WCRP-CMIP/CMIP6Plus_CVs/releases/tag/v6.5.0.0",
+            "CV_collection_modified": "2024-02-12T16:13:34Z",
+            "CV_collection_release": "https://github.com/WCRP-CMIP/CMIP6Plus_CVs/releases/tag/v6.5.1.0",
             "specs_doc": "v6.5.0"
         },
         "file": {
             "checksum": "md5: 73347d15310b24f863ddab04ce5fb821",
-            "tracking_id_update_commit": "8a5ecc14d6a5d84c4a828f67fd537f4daf80d761",
-            "tracking_id_modified": "Mon Feb 12 16:11:03 2024 +0000",
-            "tracking_id_note": "Tag and Release (#56)"
+            "tracking_id_update_commit": "",
+            "tracking_id_modified": "",
+            "tracking_id_note": ""
         },
         "author": "Daniel Ellis",
         "institution_id": "CMIP-IPO"

--- a/CVs/CMIP6Plus_CV_issue58_matthew-mizielinski_minor-tweaks-CV-json.json
+++ b/CVs/CMIP6Plus_CV_issue58_matthew-mizielinski_minor-tweaks-CV-json.json
@@ -1081,12 +1081,12 @@
             "r[[:digit:]]\\{1,\\}i[[:digit:]]\\{1,\\}p[[:digit:]]\\{1,\\}f[[:digit:]]\\{1,\\}$"
         ],
         "version_metadata": {
-            "file_updated": "Mon Feb 19 2024 11:22 UTC",
+            "file_updated": "Mon Feb 19 2024 11:29 UTC",
             "checksum": "",
             "CVs": {
-                "updated": "2024-02-19T11:21:31Z",
+                "updated": "2024-02-19T11:28:42Z",
                 "tag": "v6.5.1.0",
-                "commit": "977aa6d35b0e777d1bd7936181ac8841b5bff639"
+                "commit": "0019c021118a37f580267ad791d5295c77560bbf"
             },
             "MIP tables": {
                 "updated": "2023-11-30T15:33:29Z",


### PR DESCRIPTION
Two minor tweaks to CV.json file generation:
* Avoid `institution` strings starting with `" - "` as is currently the case for MOHC (CMOR seems to remove the initial space)
* Bracket missing in `source` string after year.
