### PR TITLE
remove trailing space in TIPMIP ramp-down experiment attribute

### DIFF
--- a/CMIP6Plus_experiment_id.json
+++ b/CMIP6Plus_experiment_id.json
@@ -714,7 +714,7 @@
             ],
             "description": "ramp down after temporary overshoot to GWL4",
             "end": "",
-            "experiment": "ramp down simulation with CO2 emissions that are the negative of those used in esm-up2p0, branching off from esm-up2p0-gwl4p0 after 50 years ",
+            "experiment": "ramp down simulation with CO2 emissions that are the negative of those used in esm-up2p0, branching off from esm-up2p0-gwl4p0 after 50 years",
             "experiment_id": "esm-up2p0-gwl4p0-50y-dn2p0",
             "min_number_yrs_per_sim": 200,
             "parent_activity_id": [


### PR DESCRIPTION
Repeats #117, this time (hopefully) properly

#117 unfortunately had no effect on CMIP6Plus_CV.json, l.670 still has the trailing space at the end of the experiment attribute. My bad, I did the change directly in CMIP6Plus_CV.json unaware that this file is automatically recreated for each release. This time the fix should be in the correct file.

Sorry @matthew-mizielinski to bother you again.

 