### PR TITLE
feat: add missing terms for variable_id

### DIFF
--- a/variable_id/simassacrossline.json
+++ b/variable_id/simassacrossline.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "simassacrossline",
+  "type": "variable"
+}

--- a/variable_id/simpconc.json
+++ b/variable_id/simpconc.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "simpconc",
+  "type": "variable"
+}

--- a/variable_id/simpmass.json
+++ b/variable_id/simpmass.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "simpmass",
+  "type": "variable"
+}

--- a/variable_id/simprefrozen.json
+++ b/variable_id/simprefrozen.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "simprefrozen",
+  "type": "variable"
+}

--- a/variable_id/sipr.json
+++ b/variable_id/sipr.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sipr",
+  "type": "variable"
+}

--- a/variable_id/sirdgconc.json
+++ b/variable_id/sirdgconc.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sirdgconc",
+  "type": "variable"
+}

--- a/variable_id/sirdgthick.json
+++ b/variable_id/sirdgthick.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sirdgthick",
+  "type": "variable"
+}

--- a/variable_id/sisnconc.json
+++ b/variable_id/sisnconc.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sisnconc",
+  "type": "variable"
+}

--- a/variable_id/sltbasin.json
+++ b/variable_id/sltbasin.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sltbasin",
+  "type": "variable"
+}

--- a/variable_id/slthick.json
+++ b/variable_id/slthick.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "slthick",
+  "type": "variable"
+}

--- a/variable_id/smc.json
+++ b/variable_id/smc.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "smc",
+  "type": "variable"
+}

--- a/variable_id/sncis.json
+++ b/variable_id/sncis.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sncis",
+  "type": "variable"
+}

--- a/variable_id/sndmasswindrif.json
+++ b/variable_id/sndmasswindrif.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sndmasswindrif",
+  "type": "variable"
+}

--- a/variable_id/snicefreez.json
+++ b/variable_id/snicefreez.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "snicefreez",
+  "type": "variable"
+}

--- a/variable_id/snicefreezis.json
+++ b/variable_id/snicefreezis.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "snicefreezis",
+  "type": "variable"
+}

--- a/variable_id/snicem.json
+++ b/variable_id/snicem.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "snicem",
+  "type": "variable"
+}

--- a/variable_id/snicemis.json
+++ b/variable_id/snicemis.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "snicemis",
+  "type": "variable"
+}

--- a/variable_id/snm.json
+++ b/variable_id/snm.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "snm",
+  "type": "variable"
+}

--- a/variable_id/snmassacrossline.json
+++ b/variable_id/snmassacrossline.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "snmassacrossline",
+  "type": "variable"
+}

--- a/variable_id/snmis.json
+++ b/variable_id/snmis.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "snmis",
+  "type": "variable"
+}

--- a/variable_id/snmsl.json
+++ b/variable_id/snmsl.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "snmsl",
+  "type": "variable"
+}

--- a/variable_id/snowmxrat27.json
+++ b/variable_id/snowmxrat27.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "snowmxrat27",
+  "type": "variable"
+}

--- a/variable_id/snrefr.json
+++ b/variable_id/snrefr.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "snrefr",
+  "type": "variable"
+}

--- a/variable_id/snwc.json
+++ b/variable_id/snwc.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "snwc",
+  "type": "variable"
+}

--- a/variable_id/so2.json
+++ b/variable_id/so2.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "so2",
+  "type": "variable"
+}

--- a/variable_id/solbnd.json
+++ b/variable_id/solbnd.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "solbnd",
+  "type": "variable"
+}

--- a/variable_id/somint.json
+++ b/variable_id/somint.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "somint",
+  "type": "variable"
+}

--- a/variable_id/sootsn.json
+++ b/variable_id/sootsn.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sootsn",
+  "type": "variable"
+}

--- a/variable_id/sossq.json
+++ b/variable_id/sossq.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sossq",
+  "type": "variable"
+}

--- a/variable_id/spco2abio.json
+++ b/variable_id/spco2abio.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "spco2abio",
+  "type": "variable"
+}

--- a/variable_id/spco2nat.json
+++ b/variable_id/spco2nat.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "spco2nat",
+  "type": "variable"
+}

--- a/variable_id/strbasemag.json
+++ b/variable_id/strbasemag.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "strbasemag",
+  "type": "variable"
+}

--- a/variable_id/sw.json
+++ b/variable_id/sw.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sw",
+  "type": "variable"
+}

--- a/variable_id/sw17o.json
+++ b/variable_id/sw17o.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sw17o",
+  "type": "variable"
+}

--- a/variable_id/sw18o.json
+++ b/variable_id/sw18o.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sw18o",
+  "type": "variable"
+}

--- a/variable_id/sw2h.json
+++ b/variable_id/sw2h.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sw2h",
+  "type": "variable"
+}

--- a/variable_id/swelut.json
+++ b/variable_id/swelut.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "swelut",
+  "type": "variable"
+}

--- a/variable_id/swsffluxaero.json
+++ b/variable_id/swsffluxaero.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "swsffluxaero",
+  "type": "variable"
+}

--- a/variable_id/swsrfasdust.json
+++ b/variable_id/swsrfasdust.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "swsrfasdust",
+  "type": "variable"
+}

--- a/variable_id/swsrfcsdust.json
+++ b/variable_id/swsrfcsdust.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "swsrfcsdust",
+  "type": "variable"
+}

--- a/variable_id/swtoaasdust.json
+++ b/variable_id/swtoaasdust.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "swtoaasdust",
+  "type": "variable"
+}

--- a/variable_id/swtoacsdust.json
+++ b/variable_id/swtoacsdust.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "swtoacsdust",
+  "type": "variable"
+}

--- a/variable_id/swtoafluxaerocs.json
+++ b/variable_id/swtoafluxaerocs.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "swtoafluxaerocs",
+  "type": "variable"
+}

--- a/variable_id/sza.json
+++ b/variable_id/sza.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "sza",
+  "type": "variable"
+}

--- a/variable_id/t2.json
+++ b/variable_id/t2.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "t2",
+  "type": "variable"
+}

--- a/variable_id/ta27.json
+++ b/variable_id/ta27.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta27",
+  "type": "variable"
+}

--- a/variable_id/ta500.json
+++ b/variable_id/ta500.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta500",
+  "type": "variable"
+}

--- a/variable_id/ta700.json
+++ b/variable_id/ta700.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta700",
+  "type": "variable"
+}

--- a/variable_id/ta7h.json
+++ b/variable_id/ta7h.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta7h",
+  "type": "variable"
+}

--- a/variable_id/ta850.json
+++ b/variable_id/ta850.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ta850",
+  "type": "variable"
+}

--- a/variable_id/talknat.json
+++ b/variable_id/talknat.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "talknat",
+  "type": "variable"
+}

--- a/variable_id/talknatos.json
+++ b/variable_id/talknatos.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "talknatos",
+  "type": "variable"
+}

--- a/variable_id/talkos.json
+++ b/variable_id/talkos.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "talkos",
+  "type": "variable"
+}

--- a/variable_id/tasis.json
+++ b/variable_id/tasis.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tasis",
+  "type": "variable"
+}

--- a/variable_id/taslut.json
+++ b/variable_id/taslut.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "taslut",
+  "type": "variable"
+}

--- a/variable_id/tasmaxcrop.json
+++ b/variable_id/tasmaxcrop.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tasmaxcrop",
+  "type": "variable"
+}

--- a/variable_id/tasmincrop.json
+++ b/variable_id/tasmincrop.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tasmincrop",
+  "type": "variable"
+}

--- a/variable_id/tatp.json
+++ b/variable_id/tatp.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tatp",
+  "type": "variable"
+}

--- a/variable_id/tau.json
+++ b/variable_id/tau.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tau",
+  "type": "variable"
+}

--- a/variable_id/tauucorr.json
+++ b/variable_id/tauucorr.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tauucorr",
+  "type": "variable"
+}

--- a/variable_id/tauupbl.json
+++ b/variable_id/tauupbl.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tauupbl",
+  "type": "variable"
+}

--- a/variable_id/tauvcorr.json
+++ b/variable_id/tauvcorr.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tauvcorr",
+  "type": "variable"
+}

--- a/variable_id/tauvpbl.json
+++ b/variable_id/tauvpbl.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tauvpbl",
+  "type": "variable"
+}

--- a/variable_id/tcs.json
+++ b/variable_id/tcs.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tcs",
+  "type": "variable"
+}

--- a/variable_id/tdps.json
+++ b/variable_id/tdps.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tdps",
+  "type": "variable"
+}

--- a/variable_id/tendacabf.json
+++ b/variable_id/tendacabf.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tendacabf",
+  "type": "variable"
+}

--- a/variable_id/tendlibmassbf.json
+++ b/variable_id/tendlibmassbf.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tendlibmassbf",
+  "type": "variable"
+}

--- a/variable_id/tendlicalvf.json
+++ b/variable_id/tendlicalvf.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tendlicalvf",
+  "type": "variable"
+}

--- a/variable_id/tgs.json
+++ b/variable_id/tgs.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tgs",
+  "type": "variable"
+}

--- a/variable_id/thetaot2000.json
+++ b/variable_id/thetaot2000.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "thetaot2000",
+  "type": "variable"
+}

--- a/variable_id/thetaot300.json
+++ b/variable_id/thetaot300.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "thetaot300",
+  "type": "variable"
+}

--- a/variable_id/thetaot700.json
+++ b/variable_id/thetaot700.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "thetaot700",
+  "type": "variable"
+}

--- a/variable_id/tnhus.json
+++ b/variable_id/tnhus.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tnhus",
+  "type": "variable"
+}

--- a/variable_id/tnhusa.json
+++ b/variable_id/tnhusa.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tnhusa",
+  "type": "variable"
+}

--- a/variable_id/tnhusc.json
+++ b/variable_id/tnhusc.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tnhusc",
+  "type": "variable"
+}

--- a/variable_id/tnhusd.json
+++ b/variable_id/tnhusd.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tnhusd",
+  "type": "variable"
+}

--- a/variable_id/tnhusmp.json
+++ b/variable_id/tnhusmp.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tnhusmp",
+  "type": "variable"
+}

--- a/variable_id/tnhuspbl.json
+++ b/variable_id/tnhuspbl.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tnhuspbl",
+  "type": "variable"
+}

--- a/variable_id/tnhusscp.json
+++ b/variable_id/tnhusscp.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tnhusscp",
+  "type": "variable"
+}

--- a/variable_id/tnhusscpbl.json
+++ b/variable_id/tnhusscpbl.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tnhusscpbl",
+  "type": "variable"
+}

--- a/variable_id/tnkebto.json
+++ b/variable_id/tnkebto.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tnkebto",
+  "type": "variable"
+}

--- a/variable_id/tnkebto2d.json
+++ b/variable_id/tnkebto2d.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tnkebto2d",
+  "type": "variable"
+}

--- a/variable_id/tnpeo.json
+++ b/variable_id/tnpeo.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tnpeo",
+  "type": "variable"
+}

--- a/variable_id/tnpeot.json
+++ b/variable_id/tnpeot.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tnpeot",
+  "type": "variable"
+}

--- a/variable_id/tnpeotb.json
+++ b/variable_id/tnpeotb.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tnpeotb",
+  "type": "variable"
+}

--- a/variable_id/tnt.json
+++ b/variable_id/tnt.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tnt",
+  "type": "variable"
+}

--- a/variable_id/tnta.json
+++ b/variable_id/tnta.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tnta",
+  "type": "variable"
+}

--- a/variable_id/tntc.json
+++ b/variable_id/tntc.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tntc",
+  "type": "variable"
+}

--- a/variable_id/tntd.json
+++ b/variable_id/tntd.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tntd",
+  "type": "variable"
+}

--- a/variable_id/tntmp.json
+++ b/variable_id/tntmp.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tntmp",
+  "type": "variable"
+}

--- a/variable_id/tntmp27.json
+++ b/variable_id/tntmp27.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tntmp27",
+  "type": "variable"
+}

--- a/variable_id/tntnogw.json
+++ b/variable_id/tntnogw.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tntnogw",
+  "type": "variable"
+}

--- a/variable_id/tntogw.json
+++ b/variable_id/tntogw.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tntogw",
+  "type": "variable"
+}

--- a/variable_id/tntpbl.json
+++ b/variable_id/tntpbl.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tntpbl",
+  "type": "variable"
+}

--- a/variable_id/tntr.json
+++ b/variable_id/tntr.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tntr",
+  "type": "variable"
+}

--- a/variable_id/tntr27.json
+++ b/variable_id/tntr27.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tntr27",
+  "type": "variable"
+}

--- a/variable_id/tntrl.json
+++ b/variable_id/tntrl.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tntrl",
+  "type": "variable"
+}

--- a/variable_id/tntrl27.json
+++ b/variable_id/tntrl27.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tntrl27",
+  "type": "variable"
+}

--- a/variable_id/tntrlcs.json
+++ b/variable_id/tntrlcs.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tntrlcs",
+  "type": "variable"
+}

--- a/variable_id/tntrs.json
+++ b/variable_id/tntrs.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tntrs",
+  "type": "variable"
+}

--- a/variable_id/tntrs27.json
+++ b/variable_id/tntrs27.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tntrs27",
+  "type": "variable"
+}

--- a/variable_id/tntrscs.json
+++ b/variable_id/tntrscs.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tntrscs",
+  "type": "variable"
+}

--- a/variable_id/tntscp.json
+++ b/variable_id/tntscp.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tntscp",
+  "type": "variable"
+}

--- a/variable_id/tntscpbl.json
+++ b/variable_id/tntscpbl.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tntscpbl",
+  "type": "variable"
+}

--- a/variable_id/topg.json
+++ b/variable_id/topg.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "topg",
+  "type": "variable"
+}

--- a/variable_id/toz.json
+++ b/variable_id/toz.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "toz",
+  "type": "variable"
+}

--- a/variable_id/tpf.json
+++ b/variable_id/tpf.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tpf",
+  "type": "variable"
+}

--- a/variable_id/tr.json
+++ b/variable_id/tr.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tr",
+  "type": "variable"
+}

--- a/variable_id/tran.json
+++ b/variable_id/tran.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tran",
+  "type": "variable"
+}

--- a/variable_id/treefracprimdec.json
+++ b/variable_id/treefracprimdec.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "treefracprimdec",
+  "type": "variable"
+}

--- a/variable_id/treefracprimever.json
+++ b/variable_id/treefracprimever.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "treefracprimever",
+  "type": "variable"
+}

--- a/variable_id/treefracsecdec.json
+++ b/variable_id/treefracsecdec.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "treefracsecdec",
+  "type": "variable"
+}

--- a/variable_id/treefracsecever.json
+++ b/variable_id/treefracsecever.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "treefracsecever",
+  "type": "variable"
+}

--- a/variable_id/tropoz.json
+++ b/variable_id/tropoz.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tropoz",
+  "type": "variable"
+}

--- a/variable_id/tsis.json
+++ b/variable_id/tsis.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tsis",
+  "type": "variable"
+}

--- a/variable_id/tsl.json
+++ b/variable_id/tsl.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tsl",
+  "type": "variable"
+}

--- a/variable_id/tsland.json
+++ b/variable_id/tsland.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tsland",
+  "type": "variable"
+}

--- a/variable_id/tslsi.json
+++ b/variable_id/tslsi.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tslsi",
+  "type": "variable"
+}

--- a/variable_id/tslsilut.json
+++ b/variable_id/tslsilut.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tslsilut",
+  "type": "variable"
+}

--- a/variable_id/tsn.json
+++ b/variable_id/tsn.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tsn",
+  "type": "variable"
+}

--- a/variable_id/tsnis.json
+++ b/variable_id/tsnis.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tsnis",
+  "type": "variable"
+}

--- a/variable_id/tsns.json
+++ b/variable_id/tsns.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tsns",
+  "type": "variable"
+}

--- a/variable_id/tsoilpools.json
+++ b/variable_id/tsoilpools.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "tsoilpools",
+  "type": "variable"
+}

--- a/variable_id/ttop.json
+++ b/variable_id/ttop.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ttop",
+  "type": "variable"
+}

--- a/variable_id/twap.json
+++ b/variable_id/twap.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "twap",
+  "type": "variable"
+}

--- a/variable_id/u2.json
+++ b/variable_id/u2.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "u2",
+  "type": "variable"
+}

--- a/variable_id/ua.json
+++ b/variable_id/ua.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua",
+  "type": "variable"
+}

--- a/variable_id/ua10.json
+++ b/variable_id/ua10.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua10",
+  "type": "variable"
+}

--- a/variable_id/ua100m.json
+++ b/variable_id/ua100m.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua100m",
+  "type": "variable"
+}

--- a/variable_id/ua27.json
+++ b/variable_id/ua27.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua27",
+  "type": "variable"
+}

--- a/variable_id/ua7h.json
+++ b/variable_id/ua7h.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ua7h",
+  "type": "variable"
+}

--- a/variable_id/ugrido.json
+++ b/variable_id/ugrido.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ugrido",
+  "type": "variable"
+}

--- a/variable_id/uqint.json
+++ b/variable_id/uqint.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "uqint",
+  "type": "variable"
+}

--- a/variable_id/ut.json
+++ b/variable_id/ut.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ut",
+  "type": "variable"
+}

--- a/variable_id/utendepfd.json
+++ b/variable_id/utendepfd.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "utendepfd",
+  "type": "variable"
+}

--- a/variable_id/utendnogw.json
+++ b/variable_id/utendnogw.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "utendnogw",
+  "type": "variable"
+}

--- a/variable_id/utendnogw27.json
+++ b/variable_id/utendnogw27.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "utendnogw27",
+  "type": "variable"
+}

--- a/variable_id/utendogw.json
+++ b/variable_id/utendogw.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "utendogw",
+  "type": "variable"
+}

--- a/variable_id/utendvtem.json
+++ b/variable_id/utendvtem.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "utendvtem",
+  "type": "variable"
+}

--- a/variable_id/utendwtem.json
+++ b/variable_id/utendwtem.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "utendwtem",
+  "type": "variable"
+}

--- a/variable_id/uv.json
+++ b/variable_id/uv.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "uv",
+  "type": "variable"
+}

--- a/variable_id/uwap.json
+++ b/variable_id/uwap.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "uwap",
+  "type": "variable"
+}

--- a/variable_id/v2.json
+++ b/variable_id/v2.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "v2",
+  "type": "variable"
+}

--- a/variable_id/va.json
+++ b/variable_id/va.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va",
+  "type": "variable"
+}

--- a/variable_id/va100m.json
+++ b/variable_id/va100m.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va100m",
+  "type": "variable"
+}

--- a/variable_id/va27.json
+++ b/variable_id/va27.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va27",
+  "type": "variable"
+}

--- a/variable_id/va7h.json
+++ b/variable_id/va7h.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "va7h",
+  "type": "variable"
+}

--- a/variable_id/vegheight.json
+++ b/variable_id/vegheight.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "vegheight",
+  "type": "variable"
+}

--- a/variable_id/vegheightcrop.json
+++ b/variable_id/vegheightcrop.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "vegheightcrop",
+  "type": "variable"
+}

--- a/variable_id/vegheightgrass.json
+++ b/variable_id/vegheightgrass.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "vegheightgrass",
+  "type": "variable"
+}

--- a/variable_id/vegheightpasture.json
+++ b/variable_id/vegheightpasture.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "vegheightpasture",
+  "type": "variable"
+}

--- a/variable_id/vegheightshrub.json
+++ b/variable_id/vegheightshrub.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "vegheightshrub",
+  "type": "variable"
+}

--- a/variable_id/vmrox.json
+++ b/variable_id/vmrox.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "vmrox",
+  "type": "variable"
+}

--- a/variable_id/volcello.json
+++ b/variable_id/volcello.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "volcello",
+  "type": "variable"
+}

--- a/variable_id/vortmean.json
+++ b/variable_id/vortmean.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "vortmean",
+  "type": "variable"
+}

--- a/variable_id/vqint.json
+++ b/variable_id/vqint.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "vqint",
+  "type": "variable"
+}

--- a/variable_id/vsf.json
+++ b/variable_id/vsf.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "vsf",
+  "type": "variable"
+}

--- a/variable_id/vsfcorr.json
+++ b/variable_id/vsfcorr.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "vsfcorr",
+  "type": "variable"
+}

--- a/variable_id/vsfevap.json
+++ b/variable_id/vsfevap.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "vsfevap",
+  "type": "variable"
+}

--- a/variable_id/vsfpr.json
+++ b/variable_id/vsfpr.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "vsfpr",
+  "type": "variable"
+}

--- a/variable_id/vsfriver.json
+++ b/variable_id/vsfriver.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "vsfriver",
+  "type": "variable"
+}

--- a/variable_id/vsfsit.json
+++ b/variable_id/vsfsit.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "vsfsit",
+  "type": "variable"
+}

--- a/variable_id/vt.json
+++ b/variable_id/vt.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "vt",
+  "type": "variable"
+}

--- a/variable_id/vt100.json
+++ b/variable_id/vt100.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "vt100",
+  "type": "variable"
+}

--- a/variable_id/vtem.json
+++ b/variable_id/vtem.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "vtem",
+  "type": "variable"
+}

--- a/variable_id/vtendnogw.json
+++ b/variable_id/vtendnogw.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "vtendnogw",
+  "type": "variable"
+}

--- a/variable_id/vtendnogw27.json
+++ b/variable_id/vtendnogw27.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "vtendnogw27",
+  "type": "variable"
+}

--- a/variable_id/vtendogw.json
+++ b/variable_id/vtendogw.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "vtendogw",
+  "type": "variable"
+}

--- a/variable_id/vwap.json
+++ b/variable_id/vwap.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "vwap",
+  "type": "variable"
+}

--- a/variable_id/wa.json
+++ b/variable_id/wa.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wa",
+  "type": "variable"
+}

--- a/variable_id/wap2.json
+++ b/variable_id/wap2.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wap2",
+  "type": "variable"
+}

--- a/variable_id/wap27.json
+++ b/variable_id/wap27.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wap27",
+  "type": "variable"
+}

--- a/variable_id/wap4.json
+++ b/variable_id/wap4.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wap4",
+  "type": "variable"
+}

--- a/variable_id/wap500.json
+++ b/variable_id/wap500.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wap500",
+  "type": "variable"
+}

--- a/variable_id/wap7h.json
+++ b/variable_id/wap7h.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wap7h",
+  "type": "variable"
+}

--- a/variable_id/wbptemp7h.json
+++ b/variable_id/wbptemp7h.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wbptemp7h",
+  "type": "variable"
+}

--- a/variable_id/wetbc.json
+++ b/variable_id/wetbc.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wetbc",
+  "type": "variable"
+}

--- a/variable_id/wetdust.json
+++ b/variable_id/wetdust.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wetdust",
+  "type": "variable"
+}

--- a/variable_id/wetlandch4.json
+++ b/variable_id/wetlandch4.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wetlandch4",
+  "type": "variable"
+}

--- a/variable_id/wetlandch4cons.json
+++ b/variable_id/wetlandch4cons.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wetlandch4cons",
+  "type": "variable"
+}

--- a/variable_id/wetlandch4prod.json
+++ b/variable_id/wetlandch4prod.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wetlandch4prod",
+  "type": "variable"
+}

--- a/variable_id/wetlandfrac.json
+++ b/variable_id/wetlandfrac.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wetlandfrac",
+  "type": "variable"
+}

--- a/variable_id/wetnh3.json
+++ b/variable_id/wetnh3.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wetnh3",
+  "type": "variable"
+}

--- a/variable_id/wetnh4.json
+++ b/variable_id/wetnh4.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wetnh4",
+  "type": "variable"
+}

--- a/variable_id/wetnoy.json
+++ b/variable_id/wetnoy.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wetnoy",
+  "type": "variable"
+}

--- a/variable_id/wetoa.json
+++ b/variable_id/wetoa.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wetoa",
+  "type": "variable"
+}

--- a/variable_id/wetso2.json
+++ b/variable_id/wetso2.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wetso2",
+  "type": "variable"
+}

--- a/variable_id/wetso4.json
+++ b/variable_id/wetso4.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wetso4",
+  "type": "variable"
+}

--- a/variable_id/wetss.json
+++ b/variable_id/wetss.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wetss",
+  "type": "variable"
+}

--- a/variable_id/wfcorr.json
+++ b/variable_id/wfcorr.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wfcorr",
+  "type": "variable"
+}

--- a/variable_id/wilt.json
+++ b/variable_id/wilt.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wilt",
+  "type": "variable"
+}

--- a/variable_id/wsgmax100m.json
+++ b/variable_id/wsgmax100m.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wsgmax100m",
+  "type": "variable"
+}

--- a/variable_id/wsgmax10m.json
+++ b/variable_id/wsgmax10m.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wsgmax10m",
+  "type": "variable"
+}

--- a/variable_id/wtd.json
+++ b/variable_id/wtd.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wtd",
+  "type": "variable"
+}

--- a/variable_id/wtem.json
+++ b/variable_id/wtem.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "wtem",
+  "type": "variable"
+}

--- a/variable_id/xgwdparam.json
+++ b/variable_id/xgwdparam.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "xgwdparam",
+  "type": "variable"
+}

--- a/variable_id/xvelbase.json
+++ b/variable_id/xvelbase.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "xvelbase",
+  "type": "variable"
+}

--- a/variable_id/xvelmean.json
+++ b/variable_id/xvelmean.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "xvelmean",
+  "type": "variable"
+}

--- a/variable_id/xvelsurf.json
+++ b/variable_id/xvelsurf.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "xvelsurf",
+  "type": "variable"
+}

--- a/variable_id/ygwdparam.json
+++ b/variable_id/ygwdparam.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ygwdparam",
+  "type": "variable"
+}

--- a/variable_id/yvelbase.json
+++ b/variable_id/yvelbase.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "yvelbase",
+  "type": "variable"
+}

--- a/variable_id/yvelmean.json
+++ b/variable_id/yvelmean.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "yvelmean",
+  "type": "variable"
+}

--- a/variable_id/yvelsurf.json
+++ b/variable_id/yvelsurf.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "yvelsurf",
+  "type": "variable"
+}

--- a/variable_id/zfull.json
+++ b/variable_id/zfull.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zfull",
+  "type": "variable"
+}

--- a/variable_id/zfullo.json
+++ b/variable_id/zfullo.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zfullo",
+  "type": "variable"
+}

--- a/variable_id/zg10.json
+++ b/variable_id/zg10.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg10",
+  "type": "variable"
+}

--- a/variable_id/zg100.json
+++ b/variable_id/zg100.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg100",
+  "type": "variable"
+}

--- a/variable_id/zg1000.json
+++ b/variable_id/zg1000.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg1000",
+  "type": "variable"
+}

--- a/variable_id/zg27.json
+++ b/variable_id/zg27.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg27",
+  "type": "variable"
+}

--- a/variable_id/zg500.json
+++ b/variable_id/zg500.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg500",
+  "type": "variable"
+}

--- a/variable_id/zg7h.json
+++ b/variable_id/zg7h.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg7h",
+  "type": "variable"
+}

--- a/variable_id/zg8.json
+++ b/variable_id/zg8.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zg8",
+  "type": "variable"
+}

--- a/variable_id/zhalf.json
+++ b/variable_id/zhalf.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zhalf",
+  "type": "variable"
+}

--- a/variable_id/zhalfo.json
+++ b/variable_id/zhalfo.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zhalfo",
+  "type": "variable"
+}

--- a/variable_id/zmeso.json
+++ b/variable_id/zmeso.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zmeso",
+  "type": "variable"
+}

--- a/variable_id/zmesoos.json
+++ b/variable_id/zmesoos.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zmesoos",
+  "type": "variable"
+}

--- a/variable_id/zmicro.json
+++ b/variable_id/zmicro.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zmicro",
+  "type": "variable"
+}

--- a/variable_id/zmicroos.json
+++ b/variable_id/zmicroos.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zmicroos",
+  "type": "variable"
+}

--- a/variable_id/zmisc.json
+++ b/variable_id/zmisc.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zmisc",
+  "type": "variable"
+}

--- a/variable_id/zmiscos.json
+++ b/variable_id/zmiscos.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zmiscos",
+  "type": "variable"
+}

--- a/variable_id/zmla.json
+++ b/variable_id/zmla.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zmla",
+  "type": "variable"
+}

--- a/variable_id/zmlwaero.json
+++ b/variable_id/zmlwaero.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zmlwaero",
+  "type": "variable"
+}

--- a/variable_id/zmswaero.json
+++ b/variable_id/zmswaero.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zmswaero",
+  "type": "variable"
+}

--- a/variable_id/zmtnt.json
+++ b/variable_id/zmtnt.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zmtnt",
+  "type": "variable"
+}

--- a/variable_id/zooc.json
+++ b/variable_id/zooc.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zooc",
+  "type": "variable"
+}

--- a/variable_id/zoocos.json
+++ b/variable_id/zoocos.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zoocos",
+  "type": "variable"
+}

--- a/variable_id/zossq.json
+++ b/variable_id/zossq.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zossq",
+  "type": "variable"
+}

--- a/variable_id/zsatarag.json
+++ b/variable_id/zsatarag.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zsatarag",
+  "type": "variable"
+}

--- a/variable_id/zsatcalc.json
+++ b/variable_id/zsatcalc.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zsatcalc",
+  "type": "variable"
+}

--- a/variable_id/ztp.json
+++ b/variable_id/ztp.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "ztp",
+  "type": "variable"
+}

--- a/variable_id/zvelbase.json
+++ b/variable_id/zvelbase.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zvelbase",
+  "type": "variable"
+}

--- a/variable_id/zvelsurf.json
+++ b/variable_id/zvelsurf.json
@@ -1,0 +1,5 @@
+{
+  "@context": "000_context.jsonld",
+  "id": "zvelsurf",
+  "type": "variable"
+}


### PR DESCRIPTION
Hello @ltroussellier,

following up on my [previous](https://github.com/WCRP-CMIP/CMIP6Plus_CVs/pull/165) pull request and [issue](https://github.com/ESGF/esgf-vocab/issues/217), I found some more `variable_id` terms missing.

I iterated over all available `table_id`s and extracted the corresponding `variable_entry` values from each table. I then built a deduplicated list of all variable IDs and compared it against the existing `.json` files in the CMIP6Plus vocabulary repository. 
For any variable IDs without a corresponding JSON definition, I added the missing `.json` files. As a result, all `variable_entry` values should now have a matching .json entry in CMIP6Plus.