### PR TITLE
feat: add terms for grid_label

### DIFF
--- a/grid_label/gm.json
+++ b/grid_label/gm.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gm",
+    "type": "grid"
+}

--- a/grid_label/gna.json
+++ b/grid_label/gna.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gna",
+    "type": "grid"
+}

--- a/grid_label/gng.json
+++ b/grid_label/gng.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gng",
+    "type": "grid"
+}

--- a/grid_label/gnz.json
+++ b/grid_label/gnz.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gnz",
+    "type": "grid"
+}

--- a/grid_label/gr1.json
+++ b/grid_label/gr1.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr1",
+    "type": "grid"
+}

--- a/grid_label/gr1a.json
+++ b/grid_label/gr1a.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr1a",
+    "type": "grid"
+}

--- a/grid_label/gr1g.json
+++ b/grid_label/gr1g.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr1g",
+    "type": "grid"
+}

--- a/grid_label/gr1z.json
+++ b/grid_label/gr1z.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr1z",
+    "type": "grid"
+}

--- a/grid_label/gr2.json
+++ b/grid_label/gr2.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr2",
+    "type": "grid"
+}

--- a/grid_label/gr2a.json
+++ b/grid_label/gr2a.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr2a",
+    "type": "grid"
+}

--- a/grid_label/gr2g.json
+++ b/grid_label/gr2g.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr2g",
+    "type": "grid"
+}

--- a/grid_label/gr2z.json
+++ b/grid_label/gr2z.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr2z",
+    "type": "grid"
+}

--- a/grid_label/gr3.json
+++ b/grid_label/gr3.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr3",
+    "type": "grid"
+}

--- a/grid_label/gr3a.json
+++ b/grid_label/gr3a.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr3a",
+    "type": "grid"
+}

--- a/grid_label/gr3g.json
+++ b/grid_label/gr3g.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr3g",
+    "type": "grid"
+}

--- a/grid_label/gr3z.json
+++ b/grid_label/gr3z.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr3z",
+    "type": "grid"
+}

--- a/grid_label/gr4.json
+++ b/grid_label/gr4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr4",
+    "type": "grid"
+}

--- a/grid_label/gr4a.json
+++ b/grid_label/gr4a.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr4a",
+    "type": "grid"
+}

--- a/grid_label/gr4g.json
+++ b/grid_label/gr4g.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr4g",
+    "type": "grid"
+}

--- a/grid_label/gr4z.json
+++ b/grid_label/gr4z.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr4z",
+    "type": "grid"
+}

--- a/grid_label/gr5.json
+++ b/grid_label/gr5.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr5",
+    "type": "grid"
+}

--- a/grid_label/gr5a.json
+++ b/grid_label/gr5a.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr5a",
+    "type": "grid"
+}

--- a/grid_label/gr5g.json
+++ b/grid_label/gr5g.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr5g",
+    "type": "grid"
+}

--- a/grid_label/gr5z.json
+++ b/grid_label/gr5z.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr5z",
+    "type": "grid"
+}

--- a/grid_label/gr6.json
+++ b/grid_label/gr6.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr6",
+    "type": "grid"
+}

--- a/grid_label/gr6a.json
+++ b/grid_label/gr6a.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr6a",
+    "type": "grid"
+}

--- a/grid_label/gr6g.json
+++ b/grid_label/gr6g.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr6g",
+    "type": "grid"
+}

--- a/grid_label/gr6z.json
+++ b/grid_label/gr6z.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr6z",
+    "type": "grid"
+}

--- a/grid_label/gr7.json
+++ b/grid_label/gr7.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr7",
+    "type": "grid"
+}

--- a/grid_label/gr7a.json
+++ b/grid_label/gr7a.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr7a",
+    "type": "grid"
+}

--- a/grid_label/gr7g.json
+++ b/grid_label/gr7g.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr7g",
+    "type": "grid"
+}

--- a/grid_label/gr7z.json
+++ b/grid_label/gr7z.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr7z",
+    "type": "grid"
+}

--- a/grid_label/gr8.json
+++ b/grid_label/gr8.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr8",
+    "type": "grid"
+}

--- a/grid_label/gr8a.json
+++ b/grid_label/gr8a.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr8a",
+    "type": "grid"
+}

--- a/grid_label/gr8g.json
+++ b/grid_label/gr8g.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr8g",
+    "type": "grid"
+}

--- a/grid_label/gr8z.json
+++ b/grid_label/gr8z.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr8z",
+    "type": "grid"
+}

--- a/grid_label/gr9.json
+++ b/grid_label/gr9.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr9",
+    "type": "grid"
+}

--- a/grid_label/gr9a.json
+++ b/grid_label/gr9a.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr9a",
+    "type": "grid"
+}

--- a/grid_label/gr9g.json
+++ b/grid_label/gr9g.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr9g",
+    "type": "grid"
+}

--- a/grid_label/gr9z.json
+++ b/grid_label/gr9z.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gr9z",
+    "type": "grid"
+}

--- a/grid_label/gra.json
+++ b/grid_label/gra.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "gra",
+    "type": "grid"
+}

--- a/grid_label/grg.json
+++ b/grid_label/grg.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "grg",
+    "type": "grid"
+}

--- a/grid_label/grz.json
+++ b/grid_label/grz.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "grz",
+    "type": "grid"
+}


### PR DESCRIPTION
Following up on [this](https://github.com/WCRP-CMIP/CMIP6Plus_CVs/issues/169) issue, I compared the list of `grid_label` terms allowed for CMIP6Plus: 
https://github.com/WCRP-CMIP/CMIP6Plus_CVs/blob/c3b18c69a92a53acafbd152fabac168077b95bd6/CVs/CMIP6Plus_CV.json#L3064

with the existing json files in `esgvoc` and added the json files for the grid terms for which it was missing.

@ltroussellier if you could review when you get a chance it would be great, thanks!