### PR TITLE
Add missing data specs version

### DIFF
--- a/data_specs_version/cmip6plus_6_5_0_0.json
+++ b/data_specs_version/cmip6plus_6_5_0_0.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "cmip6plus_6_5_0_0",
+    "type": "data_specs_version"
+}


### PR DESCRIPTION
@sashakames can you please add context here

This is what is required from the esgvoc side. However, I don't know how this repo is operating in practice. My guess is that this should really be a PR into main, from which the esgvoc information is auto-generated, but I don't have any experience of that so can't help any further unfortunately.